### PR TITLE
[IDP-788] Use default index name when the name is not provided

### DIFF
--- a/src/Workleap.Extensions.Mongo.Tests/UniqueIndexNameTests.cs
+++ b/src/Workleap.Extensions.Mongo.Tests/UniqueIndexNameTests.cs
@@ -1,4 +1,4 @@
-﻿using Workleap.Extensions.Xunit;
+using Workleap.Extensions.Xunit;
 using MongoDB.Driver;
 using Workleap.Extensions.Mongo.Indexing;
 
@@ -37,6 +37,19 @@ public sealed class UniqueIndexNameTests : BaseUnitTest
 
         Assert.False(result);
         Assert.Null(uxIndexName);
+    }
+
+    [Fact]
+    public void UniqueIndex_ComputeDefaultName_When_IndexName_NotSpecified()
+    {
+        var index = new CreateIndexModel<SampleDocument>(
+            Builders<SampleDocument>.IndexKeys.Ascending(x => x.SampleField),
+            options: null);
+
+        var result = UniqueIndexName.TryCreate(index, out var uxIndexName);
+
+        Assert.True(result);
+        Assert.Equal("SampleField_1", uxIndexName!.Prefix);
     }
 
     private static CreateIndexModel<SampleDocument> CreateIndex(string indexName)


### PR DESCRIPTION
<!-- Please fill out any relevant sections and remove those that don't apply -->

## Description of changes

When the index name is not provided, `TryCreate` now infers the index name using the logic provided by the MongoDB driver.

This prevent a `NullReferenceException` when `options` is null.

## Breaking changes
<!-- What breaking changes were added (if any) and how are they addressed? -->

## Additional checks
<!-- Please check what applies. Note that some of these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Updated the documentation of the project to reflect the changes
- [ ] Added new tests that cover the code changes
