### PR TITLE
[IDP-1146] Add skip-duplicate flag to nuget publish step

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -26,7 +26,7 @@ Process {
         Exec { & dotnet pack  -c Release -o "$outputDir" }
 
         if (($null -ne $env:NUGET_SOURCE ) -and ($null -ne $env:NUGET_API_KEY)) {
-            Exec { & dotnet nuget push "$nupkgsPath" -s $env:NUGET_SOURCE -k $env:NUGET_API_KEY }
+            Exec { & dotnet nuget push "$nupkgsPath" -s $env:NUGET_SOURCE -k $env:NUGET_API_KEY --skip-duplicate }
         }
     }
     finally {

--- a/src/Workleap.Extensions.Mongo.Abstractions/Workleap.Extensions.Mongo.Abstractions.csproj
+++ b/src/Workleap.Extensions.Mongo.Abstractions/Workleap.Extensions.Mongo.Abstractions.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Workleap.ComponentModel.DataAnnotations" Version="1.3.1" />
+    <PackageReference Include="Workleap.ComponentModel.DataAnnotations" Version="1.4.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Workleap.Extensions.Mongo.Analyzers.Tests/Workleap.Extensions.Mongo.Analyzers.Tests.csproj
+++ b/src/Workleap.Extensions.Mongo.Analyzers.Tests/Workleap.Extensions.Mongo.Analyzers.Tests.csproj
@@ -19,7 +19,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.1">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Workleap.Extensions.Mongo.Tests/Workleap.Extensions.Mongo.Tests.csproj
+++ b/src/Workleap.Extensions.Mongo.Tests/Workleap.Extensions.Mongo.Tests.csproj
@@ -25,7 +25,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.1">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
## Description of changes
Add a skip-duplicate flag to the NuGet publish step. Without that flag, the pipeline fails on rerun.

## Breaking changes
None

## Additional checks

- [ ] Updated the documentation of the project to reflect the changes
- [ ] Added new tests that cover the code changes
