### PR TITLE
[IDP-1146] Add timestamp to version in nuget publish step

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "gitversion.tool": {
+      "version": "5.12.0",
+      "commands": [
+        "dotnet-gitversion"
+      ]
+    }
+  }
+}

--- a/Build.ps1
+++ b/Build.ps1
@@ -26,7 +26,7 @@ Process {
         Exec { & dotnet pack  -c Release -o "$outputDir" }
 
         if (($null -ne $env:NUGET_SOURCE ) -and ($null -ne $env:NUGET_API_KEY)) {
-            Exec { & dotnet nuget push "$nupkgsPath" -s $env:NUGET_SOURCE -k $env:NUGET_API_KEY }
+            Exec { & dotnet nuget push "$nupkgsPath" -s $env:NUGET_SOURCE -k $env:NUGET_API_KEY --skip-duplicate }
         }
     }
     finally {

--- a/Build.ps1
+++ b/Build.ps1
@@ -11,7 +11,7 @@ Process {
             throw ("An error occurred while executing command: {0}" -f $Command)
         }
     }
-    
+
     $workingDir = Join-Path $PSScriptRoot "src"
     $outputDir = Join-Path $PSScriptRoot ".output"
     $nupkgsPath = Join-Path $outputDir "*.nupkg"
@@ -19,14 +19,17 @@ Process {
     try {
         Push-Location $workingDir
         Remove-Item $outputDir -Force -Recurse -ErrorAction SilentlyContinue
-    
+
+        $uniqueId = Get-Date -Format "yyyyMMddHHmmss"
+        $version = Exec { & dotnet dotnet-gitversion /output json /showvariable SemVer } + ".$uniqueId"
+
         Exec { & dotnet clean -c Release }
         Exec { & dotnet build -c Release }
         Exec { & dotnet test  -c Release --results-directory "$outputDir" --no-restore -l "trx" -l "console;verbosity=detailed" }
-        Exec { & dotnet pack  -c Release -o "$outputDir" }
+        Exec { & dotnet pack  -c Release -o "$outputDir" -Version $version }
 
         if (($null -ne $env:NUGET_SOURCE ) -and ($null -ne $env:NUGET_API_KEY)) {
-            Exec { & dotnet nuget push "$nupkgsPath" -s $env:NUGET_SOURCE -k $env:NUGET_API_KEY --skip-duplicate }
+            Exec { & dotnet nuget push "$nupkgsPath" -s $env:NUGET_SOURCE -k $env:NUGET_API_KEY }
         }
     }
     finally {

--- a/Build.ps1
+++ b/Build.ps1
@@ -25,18 +25,19 @@ Process {
         Exec { & dotnet tool restore }
 
         # Let GitVersion compute the NuGet package version
-        $shortSHA = Exec { & git rev-parse --short HEAD }
-        $gitVersion = Exec { & dotnet dotnet-gitversion /output json /showvariable SemVer }
-        $version = "$gitVersion.$shortSHA"
+        # $shortSHA = Exec { & git rev-parse --short HEAD }
+        # $gitVersion = Exec { & dotnet dotnet-gitversion /output json /showvariable SemVer }
+        # $version = "$gitVersion.$shortSHA"
 
         Exec { & dotnet clean -c Release }
         Exec { & dotnet build -c Release }
         Exec { & dotnet test  -c Release --results-directory "$outputDir" --no-restore -l "trx" -l "console;verbosity=detailed" }
-        Exec { & dotnet pack  -c Release -o "$outputDir" /p:Version=$version }
+        Exec { & dotnet pack -c Release -o "$outputDir" }
 
         if (($null -ne $env:NUGET_SOURCE ) -and ($null -ne $env:NUGET_API_KEY)) {
             Exec { & dotnet nuget push "$nupkgsPath" -s $env:NUGET_SOURCE -k $env:NUGET_API_KEY }
         }
+        Write-Host "Packing with version: $version"
     }
     finally {
         Pop-Location

--- a/Build.ps1
+++ b/Build.ps1
@@ -29,9 +29,9 @@ Process {
         $gitVersion = Exec { & dotnet dotnet-gitversion /output json /showvariable SemVer }
         $version = "$gitVersion.$uniqueId"
 
-        # Exec { & dotnet clean -c Release }
-        # Exec { & dotnet build -c Release }
-        # Exec { & dotnet test  -c Release --results-directory "$outputDir" --no-restore -l "trx" -l "console;verbosity=detailed" }
+        Exec { & dotnet clean -c Release }
+        Exec { & dotnet build -c Release }
+        Exec { & dotnet test  -c Release --results-directory "$outputDir" --no-restore -l "trx" -l "console;verbosity=detailed" }
         Exec { & dotnet pack  -c Release -o "$outputDir" /p:Version=$version }
 
         if (($null -ne $env:NUGET_SOURCE ) -and ($null -ne $env:NUGET_API_KEY)) {

--- a/Build.ps1
+++ b/Build.ps1
@@ -29,10 +29,10 @@ Process {
         $gitVersion = Exec { & dotnet dotnet-gitversion /output json /showvariable SemVer }
         $version = "$gitVersion.$uniqueId"
 
-        Exec { & dotnet clean -c Release }
-        Exec { & dotnet build -c Release }
-        Exec { & dotnet test  -c Release --results-directory "$outputDir" --no-restore -l "trx" -l "console;verbosity=detailed" }
-        Exec { & dotnet pack  -c Release -o "$outputDir" -Version $version }
+        # Exec { & dotnet clean -c Release }
+        # Exec { & dotnet build -c Release }
+        # Exec { & dotnet test  -c Release --results-directory "$outputDir" --no-restore -l "trx" -l "console;verbosity=detailed" }
+        Exec { & dotnet pack  -c Release -o "$outputDir" /p:Version=$version }
 
         if (($null -ne $env:NUGET_SOURCE ) -and ($null -ne $env:NUGET_API_KEY)) {
             Exec { & dotnet nuget push "$nupkgsPath" -s $env:NUGET_SOURCE -k $env:NUGET_API_KEY }

--- a/Build.ps1
+++ b/Build.ps1
@@ -25,9 +25,9 @@ Process {
         Exec { & dotnet tool restore }
 
         # Let GitVersion compute the NuGet package version
-        $uniqueId = Get-Date -Format "yyyyMMddHHmmss"
+        $shortSHA = Exec { & git rev-parse --short HEAD }
         $gitVersion = Exec { & dotnet dotnet-gitversion /output json /showvariable SemVer }
-        $version = "$gitVersion.$uniqueId"
+        $version = "$gitVersion.$shortSHA"
 
         Exec { & dotnet clean -c Release }
         Exec { & dotnet build -c Release }

--- a/Build.ps1
+++ b/Build.ps1
@@ -20,8 +20,14 @@ Process {
         Push-Location $workingDir
         Remove-Item $outputDir -Force -Recurse -ErrorAction SilentlyContinue
 
+        # Install GitVersion which is specified in the .config/dotnet-tools.json
+        # https://learn.microsoft.com/en-us/dotnet/core/tools/local-tools-how-to-use
+        Exec { & dotnet tool restore }
+
+        # Let GitVersion compute the NuGet package version
         $uniqueId = Get-Date -Format "yyyyMMddHHmmss"
-        $version = Exec { & dotnet dotnet-gitversion /output json /showvariable SemVer } + ".$uniqueId"
+        $gitVersion = Exec { & dotnet dotnet-gitversion /output json /showvariable SemVer }
+        $version = "$gitVersion.$uniqueId"
 
         Exec { & dotnet clean -c Release }
         Exec { & dotnet build -c Release }

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -66,6 +66,7 @@ branches:
     is-release-branch: false
     is-mainline: false
     pre-release-weight: 30000
+    assembly-informational-format: '{InformationalVersion}'
   pull-request:
     regex: ^(pull|pull\-requests|pr)[/-]
     mode: ContinuousDelivery
@@ -80,6 +81,7 @@ branches:
     is-release-branch: false
     is-mainline: false
     pre-release-weight: 30000
+    assembly-informational-format: '{InformationalVersion}'
   hotfix:
     regex: ^hotfix(es)?[/-]
     mode: ContinuousDelivery


### PR DESCRIPTION
## Description of changes
To ensure we are publishing a new version with each PR, we can add a timestamp ID to the version value.

## Breaking changes
None

## Additional checks

- [ ] Updated the documentation of the project to reflect the changes
- [ ] Added new tests that cover the code changes
