### PR TITLE
Feature/sre 3456 add optional diagnostics tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ services.AddMongo().AddApplicationInsights();
 ```
 
 By default, some commands such as `isMaster`, `buildInfo`, `saslStart`, etc., are ignored by our instrumentation. You can either ignore additional commands or undo the ignoring of commands by modifying the `MongoClientOptions.Telemetry.DefaultIgnoredCommandNames` collection.
+Additionally, subscribing to more granular driver diagnostic events can be done by setting `MongoClientOptions.Telemetry.CaptureDiagnosticEvents` to `true`.
 
 ## Index management
 

--- a/src/Workleap.Extensions.Mongo.Tests/DiagnosticsEventSubscriberTests.cs
+++ b/src/Workleap.Extensions.Mongo.Tests/DiagnosticsEventSubscriberTests.cs
@@ -1,4 +1,3 @@
-using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
 using System.Net;
 using MongoDB.Bson;

--- a/src/Workleap.Extensions.Mongo.Tests/DiagnosticsEventSubscriberTests.cs
+++ b/src/Workleap.Extensions.Mongo.Tests/DiagnosticsEventSubscriberTests.cs
@@ -1,0 +1,78 @@
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
+using System.Net;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using MongoDB.Driver.Core.Clusters;
+using MongoDB.Driver.Core.Connections;
+using MongoDB.Driver.Core.Events;
+using MongoDB.Driver.Core.Servers;
+using Workleap.Extensions.Mongo.Telemetry;
+
+namespace Workleap.Extensions.Mongo.Tests
+{
+    public class DiagnosticsEventSubscriberTests
+    {
+        static DiagnosticsEventSubscriberTests()
+        {
+            Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+            Activity.ForceDefaultIdFormat = true;
+        }
+
+        [Fact]
+        public void Should_Record_Diagnostics_Events_When_Option_Set()
+        {
+            var stopFired = false;
+            var startFired = false;
+
+            var command = new BsonDocument(new Dictionary<string, object>
+            {
+                { "update", "my_collection" },
+            });
+
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = source => source.Name == "Workleap.Extensions.Mongo",
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+                ActivityStarted = activity =>
+                {
+                    startFired = true;
+                    Assert.NotNull(activity);
+                },
+                ActivityStopped = activity =>
+                {
+                    Assert.NotNull(activity);
+                    Assert.Equal("MongoDB.Driver.Core.Events.Command", activity.OperationName);
+                    var activityEvents = activity.Events;
+                    Assert.Single(activityEvents);
+                    var connPoolAddedConnEvent = activityEvents.First();
+                    Assert.Equal("ConnectionPoolAddedConnectionEvent", connPoolAddedConnEvent.Name);
+                    var operationId = connPoolAddedConnEvent.Tags.SingleOrDefault(t => t.Key == "db.mongodb.OperationId");                   
+                    Assert.Equal(Convert.ToInt64(1), operationId.Value);
+
+                    stopFired = true;
+                },
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            var options = new MongoClientOptions();
+            options.Telemetry.CaptureDiagnosticEvents = true;
+
+            var tracingBehavior = new CommandTracingEventSubscriber(options);
+            var diagnosticsBehavior = new DiagnosticsTracingEventSubscriber(options);
+
+            Assert.True(tracingBehavior.TryGetEventHandler<CommandStartedEvent>(out var startEvent));
+            Assert.True(diagnosticsBehavior.TryGetEventHandler<ConnectionPoolAddedConnectionEvent>(out var connPoolAddedConnEvent));
+            Assert.True(tracingBehavior.TryGetEventHandler<CommandSucceededEvent>(out var stopEvent));
+
+            var connectionId = new ConnectionId(new ServerId(new ClusterId(), new DnsEndPoint("localhost", 8000)));
+            var databaseNamespace = new DatabaseNamespace("test");
+            startEvent(new CommandStartedEvent("update", command, databaseNamespace, null, 1, connectionId));
+            connPoolAddedConnEvent(new ConnectionPoolAddedConnectionEvent(connectionId, TimeSpan.Zero, 1));
+            stopEvent(new CommandSucceededEvent("update", command, databaseNamespace, null, 1, connectionId, TimeSpan.Zero));
+
+            Assert.True(startFired);
+            Assert.True(stopFired);
+        }
+    }
+}

--- a/src/Workleap.Extensions.Mongo/MongoClientOptions.cs
+++ b/src/Workleap.Extensions.Mongo/MongoClientOptions.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 using MongoDB.Driver;
 using MongoDB.Driver.Core.Events;
 
@@ -62,6 +62,8 @@ public sealed class MongoTelemetryOptions
     public bool CaptureCommandText { get; set; }
 
     public ISet<string> IgnoredCommandNames { get; }
+
+    public bool CaptureDiagnosticEvents { get; set; }
 }
 
 public sealed class MongoCommandPerformanceAnalysisOptions

--- a/src/Workleap.Extensions.Mongo/MongoEventSubscriberFactory.cs
+++ b/src/Workleap.Extensions.Mongo/MongoEventSubscriberFactory.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using MongoDB.Driver.Core.Events;
 using Workleap.Extensions.Mongo.Performance;
@@ -25,6 +25,12 @@ internal sealed class MongoEventSubscriberFactory : IMongoEventSubscriberFactory
 
         // Command distributed tracing (Open Telemetry)
         yield return new CommandTracingEventSubscriber(options);
+
+        // Additional diagnostic events distributed tracing (Open Telemetry)
+        if (options.Telemetry.CaptureDiagnosticEvents)
+        {
+            yield return new DiagnosticsTracingEventSubscriber(options);
+        }
 
         // Command logging
         yield return new CommandLoggingEventSubscriber(options, this._loggerFactory);

--- a/src/Workleap.Extensions.Mongo/PublicAPI.Shipped.txt
+++ b/src/Workleap.Extensions.Mongo/PublicAPI.Shipped.txt
@@ -52,6 +52,8 @@ Workleap.Extensions.Mongo.MongoStaticOptions.MongoStaticOptions() -> void
 Workleap.Extensions.Mongo.MongoTelemetryOptions
 Workleap.Extensions.Mongo.MongoTelemetryOptions.CaptureCommandText.get -> bool
 Workleap.Extensions.Mongo.MongoTelemetryOptions.CaptureCommandText.set -> void
+Workleap.Extensions.Mongo.MongoTelemetryOptions.CaptureDiagnosticEvents.get -> bool
+Workleap.Extensions.Mongo.MongoTelemetryOptions.CaptureDiagnosticEvents.set -> void
 Workleap.Extensions.Mongo.MongoTelemetryOptions.IgnoredCommandNames.get -> System.Collections.Generic.ISet<string!>!
 Workleap.Extensions.Mongo.MongoTelemetryOptions.MongoTelemetryOptions() -> void
 Workleap.Extensions.Mongo.NamedConventionPack

--- a/src/Workleap.Extensions.Mongo/PublicAPI.Unshipped.txt
+++ b/src/Workleap.Extensions.Mongo/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Workleap.Extensions.Mongo.MongoTelemetryOptions.CaptureDiagnosticEvents.get -> bool
+Workleap.Extensions.Mongo.MongoTelemetryOptions.CaptureDiagnosticEvents.set -> void

--- a/src/Workleap.Extensions.Mongo/PublicAPI.Unshipped.txt
+++ b/src/Workleap.Extensions.Mongo/PublicAPI.Unshipped.txt
@@ -1,3 +1,1 @@
 #nullable enable
-Workleap.Extensions.Mongo.MongoTelemetryOptions.CaptureDiagnosticEvents.get -> bool
-Workleap.Extensions.Mongo.MongoTelemetryOptions.CaptureDiagnosticEvents.set -> void

--- a/src/Workleap.Extensions.Mongo/Telemetry/DiagnosticsTracingEventSubscriber.cs
+++ b/src/Workleap.Extensions.Mongo/Telemetry/DiagnosticsTracingEventSubscriber.cs
@@ -1,0 +1,152 @@
+using System.Diagnostics;
+using System.Reflection;
+using MongoDB.Driver.Core.Events;
+
+namespace Workleap.Extensions.Mongo.Telemetry;
+
+// Highly inspired from Jimmy Bogard's MongoDB instrumentation library:
+// https://github.com/jbogard/MongoDB.Driver.Core.Extensions.DiagnosticSources/blob/1.3.0/src/MongoDB.Driver.Core.Extensions.DiagnosticSources/DiagnosticsActivityEventSubscriber.cs
+internal sealed class DiagnosticsTracingEventSubscriber : IEventSubscriber
+{
+    private const string MongoDbPrefix = "db.mongodb";
+    private readonly MongoClientOptions _options;
+    private readonly ReflectionEventSubscriber _subscriber;
+
+    public DiagnosticsTracingEventSubscriber(MongoClientOptions options)
+    {
+        this._options = options;
+        this._subscriber = new ReflectionEventSubscriber(this, bindingFlags: BindingFlags.Instance | BindingFlags.NonPublic);
+    }
+
+    public bool TryGetEventHandler<TEvent>(out Action<TEvent> handler)
+            => this._subscriber.TryGetEventHandler(out handler);
+
+    #region cluster events
+    private void Handle(ClusterAddedServerEvent @event) => this.HandleDiagnosticEvent(@event);
+
+    private void Handle(ClusterAddingServerEvent @event) => this.HandleDiagnosticEvent(@event);
+
+    private void Handle(ClusterClosedEvent @event) => this.HandleDiagnosticEvent(@event);
+
+    private void Handle(ClusterClosingEvent @event) => this.HandleDiagnosticEvent(@event);
+
+    private void Handle(ClusterDescriptionChangedEvent @event) => this.HandleDiagnosticEvent(@event);
+
+    private void Handle(ClusterOpenedEvent @event) => this.HandleDiagnosticEvent(@event);
+
+    private void Handle(ClusterOpeningEvent @event) => this.HandleDiagnosticEvent(@event);
+
+    private void Handle(ClusterRemovedServerEvent @event) => this.HandleDiagnosticEvent(@event);
+
+    private void Handle(ClusterRemovingServerEvent @event) => this.HandleDiagnosticEvent(@event);
+
+    private void Handle(ClusterSelectedServerEvent @event) => this.HandleDiagnosticEvent(@event);
+
+    private void Handle(ClusterSelectingServerEvent @event) => this.HandleDiagnosticEvent(@event);
+
+    private void Handle(ClusterSelectingServerFailedEvent @event) => this.HandleDiagnosticEvent(@event);
+    #endregion
+
+    #region connection events
+    private void Handle(ConnectionClosedEvent @event) => this.HandleDiagnosticEvent(@event);
+
+    private void Handle(ConnectionClosingEvent @event) => this.HandleDiagnosticEvent(@event);
+
+    private void Handle(ConnectionCreatedEvent @event) => this.HandleDiagnosticEvent(@event);
+
+    private void Handle(ConnectionFailedEvent @event) => this.HandleDiagnosticEvent(@event);
+
+    private void Handle(ConnectionOpenedEvent @event) => this.HandleDiagnosticEvent(@event);
+
+    private void Handle(ConnectionOpeningEvent @event) => this.HandleDiagnosticEvent(@event);
+
+    private void Handle(ConnectionOpeningFailedEvent @event) => this.HandleDiagnosticEvent(@event);
+
+    private void Handle(ConnectionReceivedMessageEvent @event) => this.HandleDiagnosticEvent(@event);
+
+    private void Handle(ConnectionReceivingMessageEvent @event) => this.HandleDiagnosticEvent(@event);
+
+    private void Handle(ConnectionReceivingMessageFailedEvent @event) => this.HandleDiagnosticEvent(@event);
+
+    private void Handle(ConnectionSendingMessagesEvent @event) => this.HandleDiagnosticEvent(@event);
+
+    private void Handle(ConnectionSendingMessagesFailedEvent @event) => this.HandleDiagnosticEvent(@event);
+
+    private void Handle(ConnectionSentMessagesEvent @event) => this.HandleDiagnosticEvent(@event);
+    #endregion
+
+    #region connection pool events
+    private void Handle(ConnectionPoolAddedConnectionEvent @event) => this.HandleDiagnosticEvent(@event);
+
+    private void Handle(ConnectionPoolAddingConnectionEvent @event) => this.HandleDiagnosticEvent(@event);
+
+    private void Handle(ConnectionPoolCheckedInConnectionEvent @event) => this.HandleDiagnosticEvent(@event);
+
+    private void Handle(ConnectionPoolCheckedOutConnectionEvent @event) => this.HandleDiagnosticEvent(@event);
+
+    private void Handle(ConnectionPoolCheckingInConnectionEvent @event) => this.HandleDiagnosticEvent(@event);
+
+    private void Handle(ConnectionPoolCheckingOutConnectionEvent @event) => this.HandleDiagnosticEvent(@event);
+
+    private void Handle(ConnectionPoolCheckingOutConnectionFailedEvent @event) => this.HandleDiagnosticEvent(@event);
+
+    private void Handle(ConnectionPoolClearedEvent @event) => this.HandleDiagnosticEvent(@event);
+
+    private void Handle(ConnectionPoolClearingEvent @event) => this.HandleDiagnosticEvent(@event);
+
+    private void Handle(ConnectionPoolClosedEvent @event) => this.HandleDiagnosticEvent(@event);
+
+    private void Handle(ConnectionPoolClosingEvent @event) => this.HandleDiagnosticEvent(@event);
+
+    private void Handle(ConnectionPoolOpenedEvent @event) => this.HandleDiagnosticEvent(@event);
+
+    private void Handle(ConnectionPoolOpeningEvent @event) => this.HandleDiagnosticEvent(@event);
+
+    private void Handle(ConnectionPoolReadyEvent @event) => this.HandleDiagnosticEvent(@event);
+
+    private void Handle(ConnectionPoolRemovedConnectionEvent @event) => this.HandleDiagnosticEvent(@event);
+
+    private void Handle(ConnectionPoolRemovingConnectionEvent @event) => this.HandleDiagnosticEvent(@event);
+    #endregion
+
+    #region server events
+    private void Handle(ServerClosedEvent @event) => this.HandleDiagnosticEvent(@event);
+
+    private void Handle(ServerClosingEvent @event) => this.HandleDiagnosticEvent(@event);
+
+    private void Handle(ServerDescriptionChangedEvent @event) => this.HandleDiagnosticEvent(@event);
+
+    private void Handle(ServerHeartbeatFailedEvent @event) => this.HandleDiagnosticEvent(@event);
+
+    private void Handle(ServerHeartbeatStartedEvent @event) => this.HandleDiagnosticEvent(@event);
+
+    private void Handle(ServerHeartbeatSucceededEvent @event) => this.HandleDiagnosticEvent(@event);
+
+    private void Handle(ServerOpenedEvent @event) => this.HandleDiagnosticEvent(@event);
+
+    private void Handle(ServerOpeningEvent @event) => this.HandleDiagnosticEvent(@event);
+    #endregion
+
+    private void HandleDiagnosticEvent(object diagnosticEvent)
+    {
+        if (!this._options.Telemetry.CaptureDiagnosticEvents || Activity.Current is null)
+        {
+            return;
+        }
+
+        Type t = diagnosticEvent.GetType();
+        string activityEventName = t.Name;
+        PropertyInfo[] props = t.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+
+        var tags = new List<KeyValuePair<string, object?>>(props.Length);
+        foreach (var prop in props)
+        {
+            var val = prop.GetValue(diagnosticEvent, null);
+            val ??= string.Empty;
+
+            tags.Add(new KeyValuePair<string, object?>($"{MongoDbPrefix}.{prop.Name}", val));
+        }
+
+        TracingHelper.AddSpanEventWithTags(activityEventName, tags);
+    }
+}

--- a/src/Workleap.Extensions.Mongo/Telemetry/TracingHelper.cs
+++ b/src/Workleap.Extensions.Mongo/Telemetry/TracingHelper.cs
@@ -45,8 +45,8 @@ internal static class TracingHelper
         }
     }
 
-    public static void AddSpanEventWithTags(string spanEventName, IEnumerable<KeyValuePair<string, object?>> tags)
+    public static void AddSpanEventWithTags(Activity currentActivity, string spanEventName, IEnumerable<KeyValuePair<string, object?>> tags)
     {
-        Activity.Current?.AddEvent(new ActivityEvent(spanEventName, tags: new ActivityTagsCollection(tags)));
+        currentActivity.AddEvent(new ActivityEvent(spanEventName, tags: new ActivityTagsCollection(tags)));
     }
 }

--- a/src/Workleap.Extensions.Mongo/Telemetry/TracingHelper.cs
+++ b/src/Workleap.Extensions.Mongo/Telemetry/TracingHelper.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
@@ -43,5 +43,10 @@ internal static class TracingHelper
         {
             Activity.Current = existingActivity;
         }
+    }
+
+    public static void AddSpanEventWithTags(string spanEventName, IEnumerable<KeyValuePair<string, object?>> tags)
+    {
+        Activity.Current?.AddEvent(new ActivityEvent(spanEventName, tags: new ActivityTagsCollection(tags)));
     }
 }


### PR DESCRIPTION
## Description of changes
This adds support for enabling additional mongo driver events for diagnostic purposes.  This will iterate over the different events and add them as an ActivityEvent to the current Activity.  This is flagged behind the MongoClientOptions (Telemetry) as "CaptureDiagnosticEvents".  This will help with drilling into driver behaviour in performance investigations.

## Breaking changes
None

## Additional checks

- [X] Updated the documentation of the project to reflect the changes
- [X] Added new tests that cover the code changes
