### PR TITLE
[IDP-1470] Change default MaxConnectionIdleTime to one minute

### DIFF
--- a/src/Workleap.Extensions.Mongo/MongoClientProvider.cs
+++ b/src/Workleap.Extensions.Mongo/MongoClientProvider.cs
@@ -14,11 +14,17 @@ internal sealed class MongoClientProvider : IMongoClientProvider, IDisposable
     // https://github.com/mongodb/mongo-csharp-driver/blob/v2.17.1/src/MongoDB.Driver/MongoDefaults.cs#L32
     private static readonly TimeSpan DefaultThirtySecondsConnectTimeout = TimeSpan.FromSeconds(30);
 
+    // https://github.com/mongodb/mongo-csharp-driver/blob/v2.25.0/src/MongoDB.Driver/MongoDefaults.cs#L34
+    private static readonly TimeSpan DefaultTenMinutesMaxConnectionIdleTime = TimeSpan.FromMinutes(10);
+
     // Officevibe also uses a 60 seconds socket timeout, it's better than the infinite default
     private static readonly TimeSpan ReasonableSocketTimeout = TimeSpan.FromSeconds(60);
 
     // Officevibe also uses a 10 seconds connect timeout
     private static readonly TimeSpan ReasonableConnectTimeout = TimeSpan.FromSeconds(10);
+
+    // Officevibe also uses a one minute max connection idle time
+    private static readonly TimeSpan ReasonableMaxConnectionIdleTime = TimeSpan.FromMinutes(1);
 
     private readonly IServiceProvider _serviceProvider;
     private readonly List<IDisposable> _disposableDependencies;
@@ -64,6 +70,11 @@ internal sealed class MongoClientProvider : IMongoClientProvider, IDisposable
         if (settings.ConnectTimeout == DefaultThirtySecondsConnectTimeout)
         {
             settings.ConnectTimeout = ReasonableConnectTimeout;
+        }
+
+        if (settings.MaxConnectionIdleTime == DefaultTenMinutesMaxConnectionIdleTime)
+        {
+            settings.MaxConnectionIdleTime = ReasonableMaxConnectionIdleTime;
         }
 
         var eventSubscriberFactories = this._serviceProvider.GetServices<IMongoEventSubscriberFactory>();

--- a/src/Workleap.Extensions.Mongo/MongoClientProvider.cs
+++ b/src/Workleap.Extensions.Mongo/MongoClientProvider.cs
@@ -23,8 +23,8 @@ internal sealed class MongoClientProvider : IMongoClientProvider, IDisposable
     // Officevibe also uses a 10 seconds connect timeout
     private static readonly TimeSpan ReasonableConnectTimeout = TimeSpan.FromSeconds(10);
 
-    // Officevibe also uses a one minute max connection idle time
-    private static readonly TimeSpan ReasonableMaxConnectionIdleTime = TimeSpan.FromMinutes(1);
+    // Officevibe also uses a 60 seconds max connection idle time
+    private static readonly TimeSpan ReasonableMaxConnectionIdleTime = TimeSpan.FromSeconds(60);
 
     private readonly IServiceProvider _serviceProvider;
     private readonly List<IDisposable> _disposableDependencies;


### PR DESCRIPTION
## Description of changes

Change `MongoClientSettings.MaxConnectionIdleTime` to one minute only when the existing value is the default one (10 minutes).

## Breaking changes

N/A

## Additional checks

This debugging session of one of our integration tests show that we will override the default 10 minutes by default:

![image](https://github.com/gsoft-inc/wl-extensions-mongo/assets/14242083/4fe7a97d-2a68-49ce-95f2-894cc124f26c)

