### PR TITLE
IDP-1957 - Use the shared renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,47 +1,18 @@
+
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "platform": "github",
-  "labels": ["renovate"],
   "extends": [
-    "config:base",
-    ":rebaseStalePrs"
+      "github>gsoft-inc/renovate-config"
   ],
-  "enabledManagers": [
-    "github-actions",
-    "nuget"
-  ],
-  "stabilityDays": 3,
-  "prHourlyLimit": 0,
-  "prConcurrentLimit": 0,
-  "branchConcurrentLimit": 0,
-  "dependencyDashboard": false,
-  "gitAuthor": "Renovate Bot <bot@renovateapp.com>",
   "packageRules": [
     {
       "matchManagers": ["nuget"],
-      "groupName": "NuGet dependencies"
-    },
-    {
-      "matchManagers": ["nuget"],
       "matchPackagePatterns": [
-        "^Microsoft\\.Extensions\\.",
-        "^Microsoft\\.CodeAnalysis\\.CSharp\\.",
-        "^Microsoft\\.Bcl\\.AsyncInterfaces$",
-        "^System\\."
+        "^Microsoft\\.Bcl\\.AsyncInterfaces$"
       ],
-      "groupName": "Ignored NuGet dependencies",
-      "description": "These packages are usually set to a user-defined minimal supported version such as 6.0.0 for .NET 6, and they are overriden by consuming applications",
-      "enabled": false
-    },
-    {
-      "matchPackageNames": ["dotnet-sdk"],
-      "groupName": "Dotnet SDK",
-      "description": "Only update patch and minor for the dotnet SDK version within the global.json",
-      "extends": [":disableMajorUpdates"]
-    },
-    {
-      "matchManagers": ["github-actions"],
-      "groupName": "Pipeline dependencies"
+      "extends": [
+        ":separateMajorReleases"
+      ]
     },
     {
       "matchManagers": ["nuget"],
@@ -55,9 +26,5 @@
       "description": "Newer XUnit versions have bugs that prevent the Roslyn analyzers testing engine to print detailed errors when diagnostic assertions are not right",
       "enabled": false
     }
-  ],
-  "vulnerabilityAlerts": {
-    "enabled": true,
-    "labels": ["security"]
-  }
+  ]
 }


### PR DESCRIPTION
<!-- Please fill out any relevant sections and remove those that don't apply -->

## Description of changes
<!-- What was changed in this pull request? -->
Changed the `renovate.json` to extend the  shared config from `wl-renovate-config`

## Breaking changes
<!-- What breaking changes were added (if any) and how are they addressed? -->
Behavior should stay the same

## Additional checks
<!-- Please check what applies. Note that some of these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Updated the documentation of the project to reflect the changes
- [ ] Added new tests that cover the code changes
