### PR TITLE
Add Cortex deployment tracker

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,7 @@ jobs:
     uses: workleap/wl-reusable-workflows/.github/workflows/linearb-deployment.yml@main
     with:
       environment: 'release'
+      cortexEntityIdOrTag: service-wl-extensions-mongo
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
Jira issue link: [feng-722](https://workleap.atlassian.net/browse/feng-722)

This pull request updates the `.github/workflows/publish.yml` file to include a new parameter in the deployment workflow configuration.

Workflow configuration update:

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R46): Added the `cortexEntityIdOrTag` parameter with the value `service-wl-extensions-mongo` to the `jobs:` section of the workflow. This likely associates the deployment with a specific Cortex entity or tag.