### PR TITLE
Support atlas search indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Workleap.Extensions.Mongo is a convenient set of .NET libraries designed to enha
 - [Property Mapping](#property-mapping)
 - [Logging and distributed tracing](#logging-and-distributed-tracing)
 - [Index management](#index-management)
+  - [Atlas Search indexes](#atlas-search-indexes)
 - [Field encryption](#field-encryption)
 - [Ephemeral MongoDB databases for integration tests](#ephemeral-mongodb-databases-for-integration-tests)
 - [Included Roslyn analyzers](#included-roslyn-analyzers)
@@ -41,7 +42,7 @@ Integrating the MongoDB C# driver into your C# projects can often lead to severa
 * **Support for multiple MongoDB clusters and/or databases**: You won't need to refactor your entire codebase to support multiple MongoDB data sources - it's supported by default.
 * **Elimination of boilerplate and duplicated code**: Remove redundant, copy-pasted MongoDB C# code from your codebase, enabling you to focus on actually utilizing the driver.
 * **Built-in instrumentation**: We provide built-in support for OpenTelemetry instrumentation, adhering to  [OpenTelemetry's semantic conventions for MongoDB](https://opentelemetry.io/docs/specs/semconv/database/mongodb/). Additionally, we offer an extra NuGet package for Application Insights .NET SDK support.
-* **Optional index management**: Declare indexes in your C# code, and then use our C# API to automatically create and update indexes based on what's declared in your code. Built-in Roslyn analyzers will assist developers in considering new indexes.
+* **Optional index management**: Declare regular and Atlas Search indexes in your C# code, and then use our C# API to automatically create and update indexes based on what's declared in your code. Built-in Roslyn analyzers will assist developers in considering new indexes.
 * **Optional async enumerables support**: You can simplify your code by using our extension methods that employ `IAsyncEnumerable` rather than more verbose MongoDB cursors.
 * **Optional field-level encryption**: Implement your own encrypt and decrypt methods, which can then automatically encrypt annotated MongoDB document fields for at-rest security.
 * **Optional ephemeral database for integration tests**: Each of your integration test methods can have its own new MongoDB database operating locally.
@@ -478,6 +479,48 @@ public class CatDocumentIndexes : MongoIndexProvider<PersonDocument>
     }
 }
 ```
+
+### Atlas Search indexes
+
+If you are using [MongoDB Atlas Search](https://www.mongodb.com/docs/atlas/atlas-search/), you can manage your search indexes from the same `MongoIndexProvider<TDocument>` by overriding the `CreateSearchIndexModels()` method:
+
+```csharp
+public class PersonDocumentIndexes : MongoIndexProvider<PersonDocument>
+{
+    public override IEnumerable<CreateIndexModel<PersonDocument>> CreateIndexModels()
+    {
+        yield return new CreateIndexModel<PersonDocument>(
+            Builders<PersonDocument>.IndexKeys.Ascending(x => x.Name),
+            new CreateIndexOptions { Name = "name" });
+    }
+
+    public override IEnumerable<CreateSearchIndexModel> CreateSearchIndexModels()
+    {
+        yield return new CreateSearchIndexModel("default", new BsonDocument
+        {
+            { "mappings", new BsonDocument { { "dynamic", true } } },
+        });
+    }
+}
+```
+
+The same `UpdateIndexesAsync()` call that manages regular indexes will also manage your Atlas Search indexes — no additional setup required.
+
+**Key differences from regular indexes:**
+
+- **Stable names**: Search index names are kept exactly as you provide them and are **not** hash-suffixed. This is because search index names are referenced directly in `$search` aggregation stages (e.g., `{ "$search": { "index": "default", ... } }`), so changing the name after creation would break queries.
+- **Change detection at runtime**: Because the name is stable, change detection works by comparing a SHA-256 hash of the index definition declared in code against the `latestDefinition` returned by Atlas. If they differ, the index definition is updated in-place — no drop is required.
+- **Name is required**: The `Name` property of `CreateSearchIndexModel` is mandatory. Unlike regular indexes where a name can be derived from the field list, there is no automatic fallback for search indexes.
+
+**Non-Atlas clusters:**
+
+If your cluster does not have the Atlas Search (`mongot`) process — for instance, a local Community MongoDB instance used during development or in integration tests — all search index management calls are silently skipped with a warning log message. Regular index management is **not** affected.
+
+```
+WARN: Atlas Search is not available on database 'mydb'. Skipping search index management.
+```
+
+This means you can freely declare search indexes in your providers without breaking local development or CI pipelines that run against a community MongoDB server.
 
 ## Field encryption
 

--- a/src/Workleap.Extensions.Mongo.Abstractions/MongoIndexProvider.cs
+++ b/src/Workleap.Extensions.Mongo.Abstractions/MongoIndexProvider.cs
@@ -11,4 +11,10 @@ public abstract class MongoIndexProvider<TDocument>
     public IndexKeysDefinitionBuilder<TDocument> IndexKeys => Builders<TDocument>.IndexKeys;
 
     public abstract IEnumerable<CreateIndexModel<TDocument>> CreateIndexModels();
+
+    /// <summary>
+    /// Override this method to define Atlas Search indexes for this document type.
+    /// Atlas Search indexes are managed separately from regular indexes and require a MongoDB Atlas cluster with the mongot process.
+    /// </summary>
+    public virtual IEnumerable<CreateSearchIndexModel> CreateSearchIndexModels() => [];
 }

--- a/src/Workleap.Extensions.Mongo.Abstractions/PublicAPI.Shipped.txt
+++ b/src/Workleap.Extensions.Mongo.Abstractions/PublicAPI.Shipped.txt
@@ -45,3 +45,4 @@ Workleap.Extensions.Mongo.IMongoCollectionBuilder<TDocument>.IndexProvider<TInde
 Workleap.Extensions.Mongo.IMongoCollectionConfiguration<TDocument>
 Workleap.Extensions.Mongo.IMongoCollectionConfiguration<TDocument>.Configure(Workleap.Extensions.Mongo.IMongoCollectionBuilder<TDocument!>! builder) -> void
 Workleap.Extensions.Mongo.MongoIndexProvider<TDocument>.IndexKeys.get -> MongoDB.Driver.IndexKeysDefinitionBuilder<TDocument!>!
+virtual Workleap.Extensions.Mongo.MongoIndexProvider<TDocument>.CreateSearchIndexModels() -> System.Collections.Generic.IEnumerable<MongoDB.Driver.CreateSearchIndexModel!>!

--- a/src/Workleap.Extensions.Mongo.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/Workleap.Extensions.Mongo.Abstractions/PublicAPI.Unshipped.txt
@@ -1,2 +1,1 @@
 #nullable enable
-virtual Workleap.Extensions.Mongo.MongoIndexProvider<TDocument>.CreateSearchIndexModels() -> System.Collections.Generic.IEnumerable<MongoDB.Driver.CreateSearchIndexModel!>!

--- a/src/Workleap.Extensions.Mongo.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/Workleap.Extensions.Mongo.Abstractions/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+virtual Workleap.Extensions.Mongo.MongoIndexProvider<TDocument>.CreateSearchIndexModels() -> System.Collections.Generic.IEnumerable<MongoDB.Driver.CreateSearchIndexModel!>!

--- a/src/Workleap.Extensions.Mongo.Tests/MongoIndexerSearchIndexTests.cs
+++ b/src/Workleap.Extensions.Mongo.Tests/MongoIndexerSearchIndexTests.cs
@@ -1,0 +1,137 @@
+using Microsoft.Extensions.DependencyInjection;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Workleap.Extensions.Mongo.Indexing;
+using Workleap.Extensions.Xunit;
+
+namespace Workleap.Extensions.Mongo.Tests;
+
+/// <summary>
+/// Tests for Atlas Search index support via <see cref="MongoIndexProvider{TDocument}.CreateSearchIndexModels"/>.
+/// Because integration tests run against a community MongoDB (ephemeral), Atlas Search is not available.
+/// These tests therefore validate the graceful-degradation path: search index management is silently
+/// skipped while regular index management continues to work normally.
+/// Full Atlas Search lifecycle tests (create / update / drop) require a MongoDB Atlas cluster with mongot.
+/// </summary>
+public class MongoIndexerSearchIndexTests : BaseIntegrationTest<MongoFixture>
+{
+    public MongoIndexerSearchIndexTests(MongoFixture fixture, ITestOutputHelper testOutputHelper)
+        : base(fixture, testOutputHelper)
+    {
+    }
+
+    [Fact]
+    public async Task UpdateIndexesAsync_Does_Not_Throw_When_Provider_Has_Only_Search_Indexes()
+    {
+        // A provider that has no regular indexes, only Atlas Search indexes.
+        // On a non-Atlas cluster this should complete without throwing.
+        var exception = await Record.ExceptionAsync(() =>
+            this.Services.GetRequiredService<IMongoIndexer>().UpdateIndexesAsync(new[] { typeof(SearchOnlyDocument) }));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public async Task UpdateIndexesAsync_Regular_Indexes_Are_Still_Created_When_Provider_Also_Has_Search_Indexes()
+    {
+        await this.Services.GetRequiredService<IMongoIndexer>().UpdateIndexesAsync(new[] { typeof(HybridDocument) });
+
+        var collection = this.Services.GetRequiredService<IMongoCollection<HybridDocument>>();
+        using var cursor = await collection.Indexes.ListAsync();
+        var indexNames = await cursor.ToAsyncEnumerable().Select(x => x["name"].AsString).ToArrayAsync();
+
+        // The regular index should have been created; Atlas Search index silently skipped.
+        Assert.Contains("title_", indexNames.Single(n => n.StartsWith("title_", StringComparison.Ordinal)));
+    }
+
+    [Fact]
+    public async Task UpdateIndexesAsync_Regular_Indexes_Are_Deleted_When_Provider_Also_Has_Search_Indexes()
+    {
+        // First call: create the regular index.
+        await this.Services.GetRequiredService<IMongoIndexer>().UpdateIndexesAsync(new[] { typeof(HybridDocument) });
+
+        // Second call with a provider that no longer declares the regular index.
+        // The regular index should be dropped; the missing search index management is silently skipped.
+        var exception = await Record.ExceptionAsync(() =>
+            this.Services.GetRequiredService<IMongoIndexer>().UpdateIndexesAsync(new[] { typeof(HybridDocumentWithoutRegularIndex) }));
+
+        Assert.Null(exception);
+
+        var collection = this.Services.GetRequiredService<IMongoCollection<HybridDocumentWithoutRegularIndex>>();
+        using var cursor = await collection.Indexes.ListAsync();
+        var indexNames = await cursor.ToAsyncEnumerable().Select(x => x["name"].AsString).ToArrayAsync();
+
+        // Only the default _id_ index should remain.
+        Assert.Single(indexNames);
+        Assert.Contains("_id_", indexNames);
+    }
+
+    // -----------------------------------------------------------------------
+    // Test documents and providers
+    // -----------------------------------------------------------------------
+
+    [MongoCollection("searchOnlyDocument", IndexProviderType = typeof(SearchOnlyDocumentIndexProvider))]
+    private sealed class SearchOnlyDocument : MongoDocument
+    {
+        public string Title { get; set; } = string.Empty;
+    }
+
+    private sealed class SearchOnlyDocumentIndexProvider : MongoIndexProvider<SearchOnlyDocument>
+    {
+        public override IEnumerable<CreateIndexModel<SearchOnlyDocument>> CreateIndexModels()
+            => [];
+
+        public override IEnumerable<CreateSearchIndexModel> CreateSearchIndexModels()
+        {
+            yield return new CreateSearchIndexModel("default", new BsonDocument
+            {
+                { "mappings", new BsonDocument { { "dynamic", true } } },
+            });
+        }
+    }
+
+    [MongoCollection("hybridDocument", IndexProviderType = typeof(HybridDocumentIndexProvider))]
+    private sealed class HybridDocument : MongoDocument
+    {
+        public string Title { get; set; } = string.Empty;
+    }
+
+    private sealed class HybridDocumentIndexProvider : MongoIndexProvider<HybridDocument>
+    {
+        public override IEnumerable<CreateIndexModel<HybridDocument>> CreateIndexModels()
+        {
+            yield return new CreateIndexModel<HybridDocument>(
+                Builders<HybridDocument>.IndexKeys.Ascending(x => x.Title),
+                new CreateIndexOptions { Name = "title" });
+        }
+
+        public override IEnumerable<CreateSearchIndexModel> CreateSearchIndexModels()
+        {
+            yield return new CreateSearchIndexModel("default", new BsonDocument
+            {
+                { "mappings", new BsonDocument { { "dynamic", true } } },
+            });
+        }
+    }
+
+    // Represents the "next release" where the regular index was removed.
+    [MongoCollection("hybridDocument", IndexProviderType = typeof(HybridDocumentWithoutRegularIndexProvider))]
+    private sealed class HybridDocumentWithoutRegularIndex : MongoDocument
+    {
+        public string Title { get; set; } = string.Empty;
+    }
+
+    private sealed class HybridDocumentWithoutRegularIndexProvider : MongoIndexProvider<HybridDocumentWithoutRegularIndex>
+    {
+        public override IEnumerable<CreateIndexModel<HybridDocumentWithoutRegularIndex>> CreateIndexModels()
+            => [];
+
+        public override IEnumerable<CreateSearchIndexModel> CreateSearchIndexModels()
+        {
+            yield return new CreateSearchIndexModel("default", new BsonDocument
+            {
+                { "mappings", new BsonDocument { { "dynamic", true } } },
+            });
+        }
+    }
+}

--- a/src/Workleap.Extensions.Mongo/Indexing/MongoIndexer.cs
+++ b/src/Workleap.Extensions.Mongo/Indexing/MongoIndexer.cs
@@ -11,6 +11,9 @@ internal sealed class MongoIndexer : IMongoIndexer
     private static readonly MethodInfo ProcessAsyncMethod = typeof(MongoIndexer).GetMethod(nameof(ProcessAsync), BindingFlags.NonPublic | BindingFlags.Instance)
         ?? throw new InvalidOperationException($"Could not find public instance method {nameof(MongoIndexer)}.{nameof(ProcessAsync)}");
 
+    private static readonly MethodInfo ProcessSearchIndexesAsyncMethod = typeof(MongoIndexer).GetMethod(nameof(ProcessSearchIndexesAsync), BindingFlags.NonPublic | BindingFlags.Instance)
+        ?? throw new InvalidOperationException($"Could not find private instance method {nameof(MongoIndexer)}.{nameof(ProcessSearchIndexesAsync)}");
+
     private readonly IMongoClientProvider _mongoClientProvider;
     private readonly IOptionsMonitor<MongoClientOptions> _optionsMonitor;
     private readonly ILoggerFactory _loggerFactory;
@@ -126,6 +129,7 @@ internal sealed class MongoIndexer : IMongoIndexer
         }
 
         var expectedIndexes = new Dictionary<string, IList<UniqueIndexName>>();
+        var expectedSearchIndexNames = new Dictionary<string, IList<string>>();
 
         foreach (var entry in registry)
         {
@@ -157,9 +161,33 @@ internal sealed class MongoIndexer : IMongoIndexer
             {
                 expectedIndexes.Add(collectionName, processingResult.ExpectedIndexes);
             }
+
+            var processSearchIndexesAsyncMethod = ProcessSearchIndexesAsyncMethod.MakeGenericMethod(documentType);
+            var searchTask = (Task<IList<string>>?)processSearchIndexesAsyncMethod.Invoke(this, new[] { indexProvider, database, cancellationToken })
+                ?? throw new InvalidOperationException($"'{nameof(MongoIndexer)}.{nameof(this.ProcessSearchIndexesAsync)}(...)' should have returned a task");
+
+            var expectedSearchNames = await searchTask.ConfigureAwait(false);
+
+            if (expectedSearchNames.Count > 0)
+            {
+                if (expectedSearchIndexNames.TryGetValue(collectionName, out var existingSearchNames))
+                {
+                    var concat = existingSearchNames.Concat(expectedSearchNames);
+                    expectedSearchIndexNames[collectionName] = concat.ToList();
+                }
+                else
+                {
+                    expectedSearchIndexNames.Add(collectionName, expectedSearchNames);
+                }
+            }
         }
 
         await IndexDeleter.ProcessAsync(database, expectedIndexes, this._loggerFactory, cancellationToken).ConfigureAwait(false);
+
+        if (expectedSearchIndexNames.Count > 0)
+        {
+            await SearchIndexDeleter.ProcessAsync(database, expectedSearchIndexNames, this._loggerFactory, cancellationToken).ConfigureAwait(false);
+        }
     }
 
     private static void AddConfigurationIndexes(IEnumerable<Type> documentTypes, IndexRegistry registry)
@@ -199,5 +227,11 @@ internal sealed class MongoIndexer : IMongoIndexer
         where TDocument : class
     {
         return IndexCreator<TDocument>.ProcessAsync(provider, database, this._loggerFactory, cancellationToken);
+    }
+
+    private Task<IList<string>> ProcessSearchIndexesAsync<TDocument>(MongoIndexProvider<TDocument> provider, IMongoDatabase database, CancellationToken cancellationToken)
+        where TDocument : class
+    {
+        return SearchIndexCreator<TDocument>.ProcessAsync(provider, database, this._loggerFactory, cancellationToken);
     }
 }

--- a/src/Workleap.Extensions.Mongo/Indexing/MongoIndexer.cs
+++ b/src/Workleap.Extensions.Mongo/Indexing/MongoIndexer.cs
@@ -168,26 +168,21 @@ internal sealed class MongoIndexer : IMongoIndexer
 
             var expectedSearchNames = await searchTask.ConfigureAwait(false);
 
-            if (expectedSearchNames.Count > 0)
+            if (expectedSearchIndexNames.TryGetValue(collectionName, out var existingSearchNames))
             {
-                if (expectedSearchIndexNames.TryGetValue(collectionName, out var existingSearchNames))
-                {
-                    var concat = existingSearchNames.Concat(expectedSearchNames);
-                    expectedSearchIndexNames[collectionName] = concat.ToList();
-                }
-                else
-                {
-                    expectedSearchIndexNames.Add(collectionName, expectedSearchNames);
-                }
+                var concat = existingSearchNames.Concat(expectedSearchNames);
+                expectedSearchIndexNames[collectionName] = concat.ToList();
+            }
+            else
+            {
+                // Always record the collection, even when there are no expected search indexes.
+                expectedSearchIndexNames.Add(collectionName, expectedSearchNames);
             }
         }
 
         await IndexDeleter.ProcessAsync(database, expectedIndexes, this._loggerFactory, cancellationToken).ConfigureAwait(false);
 
-        if (expectedSearchIndexNames.Count > 0)
-        {
-            await SearchIndexDeleter.ProcessAsync(database, expectedSearchIndexNames, this._loggerFactory, cancellationToken).ConfigureAwait(false);
-        }
+        await SearchIndexDeleter.ProcessAsync(database, expectedSearchIndexNames, this._loggerFactory, cancellationToken).ConfigureAwait(false);
     }
 
     private static void AddConfigurationIndexes(IEnumerable<Type> documentTypes, IndexRegistry registry)

--- a/src/Workleap.Extensions.Mongo/Indexing/SearchIndexCreator.cs
+++ b/src/Workleap.Extensions.Mongo/Indexing/SearchIndexCreator.cs
@@ -1,0 +1,142 @@
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace Workleap.Extensions.Mongo.Indexing;
+
+/// <summary>
+/// Ensures that Atlas Search indexes for a particular document type exist on the database
+/// with the desired index definitions declared in the code.
+/// </summary>
+/// <remarks>
+/// Unlike regular indexes, Atlas Search index names are NOT hash-suffixed because they are referenced
+/// by name in $search aggregation stages. Change detection is done by comparing a SHA256 hash of the
+/// definition document at runtime: once from the code, once from the 'latestDefinition' field returned
+/// by the database.
+/// </remarks>
+internal sealed class SearchIndexCreator<TDocument>
+    where TDocument : class
+{
+    private readonly MongoIndexProvider<TDocument> _provider;
+    private readonly IMongoCollection<TDocument> _collection;
+    private readonly ILogger _logger;
+    private readonly CancellationToken _cancellationToken;
+
+    private SearchIndexCreator(MongoIndexProvider<TDocument> provider, IMongoDatabase database, ILoggerFactory loggerFactory, CancellationToken cancellationToken)
+    {
+        this._provider = provider;
+        this._collection = database.GetCollection<TDocument>();
+        this._logger = loggerFactory.CreateLogger<SearchIndexCreator<TDocument>>();
+        this._cancellationToken = cancellationToken;
+    }
+
+    public static Task<IList<string>> ProcessAsync(MongoIndexProvider<TDocument> provider, IMongoDatabase database, ILoggerFactory loggerFactory, CancellationToken cancellationToken)
+    {
+        return new SearchIndexCreator<TDocument>(provider, database, loggerFactory, cancellationToken).ProcessAsync();
+    }
+
+    private async Task<IList<string>> ProcessAsync()
+    {
+        var desiredIndexModels = this._provider.CreateSearchIndexModels().ToList();
+        if (desiredIndexModels.Count == 0)
+        {
+            return [];
+        }
+
+        Dictionary<string, BsonDocument> existingIndexes;
+        try
+        {
+            existingIndexes = await this.GetExistingSearchIndexesAsync().ConfigureAwait(false);
+        }
+        catch (MongoCommandException ex) when (IsSearchNotSupportedException(ex))
+        {
+            this._logger.AtlasSearchNotAvailable(ex, this._collection.Database.DatabaseNamespace.DatabaseName);
+            return [];
+        }
+
+        this._cancellationToken.ThrowIfCancellationRequested();
+
+        var expectedNames = new List<string>(desiredIndexModels.Count);
+
+        foreach (var model in desiredIndexModels)
+        {
+            if (string.IsNullOrWhiteSpace(model.Name))
+            {
+                throw new ArgumentException($"All search indexes in '{this._provider.GetType()}' must have a non-empty Name");
+            }
+
+            expectedNames.Add(model.Name);
+
+            var desiredHash = ComputeDefinitionHash(model.Definition);
+
+            try
+            {
+                if (!existingIndexes.TryGetValue(model.Name, out var latestDefinition))
+                {
+                    this._logger.CreatingNewSearchIndex(typeof(TDocument).Name, model.Name, this._collection.Database.DatabaseNamespace.DatabaseName);
+                    await this._collection.SearchIndexes.CreateOneAsync(model, cancellationToken: this._cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    var existingHash = ComputeDefinitionHash(latestDefinition);
+                    if (existingHash == desiredHash)
+                    {
+                        this._logger.SkippingUpToDateSearchIndex(typeof(TDocument).Name, model.Name, this._collection.Database.DatabaseNamespace.DatabaseName);
+                    }
+                    else
+                    {
+                        this._logger.UpdatingSearchIndex(typeof(TDocument).Name, model.Name, this._collection.Database.DatabaseNamespace.DatabaseName);
+                        await this._collection.SearchIndexes.UpdateAsync(model.Name, model.Definition, this._cancellationToken).ConfigureAwait(false);
+                    }
+                }
+            }
+            catch (MongoCommandException ex) when (IsSearchNotSupportedException(ex))
+            {
+                this._logger.AtlasSearchNotAvailable(ex, this._collection.Database.DatabaseNamespace.DatabaseName);
+                return [];
+            }
+        }
+
+        return expectedNames;
+    }
+
+    private async Task<Dictionary<string, BsonDocument>> GetExistingSearchIndexesAsync()
+    {
+        var result = new Dictionary<string, BsonDocument>(StringComparer.Ordinal);
+
+        using var cursor = await this._collection.SearchIndexes.ListAsync(null, null, this._cancellationToken).ConfigureAwait(false);
+        var indexes = await cursor.ToListAsync(this._cancellationToken).ConfigureAwait(false);
+
+        foreach (var index in indexes)
+        {
+            var name = index["name"].AsString;
+            var latestDefinition = index.GetValue("latestDefinition", BsonNull.Value);
+            if (latestDefinition.IsBsonDocument)
+            {
+                result[name] = latestDefinition.AsBsonDocument;
+            }
+        }
+
+        return result;
+    }
+
+    private static string ComputeDefinitionHash(BsonDocument? definition)
+    {
+        if (definition is null)
+        {
+            return string.Empty;
+        }
+
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(definition.ToString()));
+        return Convert.ToHexString(hash)[..32].ToLowerInvariant();
+    }
+
+    private static bool IsSearchNotSupportedException(MongoCommandException ex)
+    {
+        // Error code 31082 is returned by non-Atlas clusters that do not have the mongot process running.
+        // https://www.mongodb.com/docs/atlas/atlas-search/atlas-search-overview/
+        return ex.Code == 31082;
+    }
+}

--- a/src/Workleap.Extensions.Mongo/Indexing/SearchIndexDeleter.cs
+++ b/src/Workleap.Extensions.Mongo/Indexing/SearchIndexDeleter.cs
@@ -1,0 +1,94 @@
+using Microsoft.Extensions.Logging;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace Workleap.Extensions.Mongo.Indexing;
+
+/// <summary>
+/// Deletes Atlas Search indexes for collections by comparing existing indexes in the database
+/// with the expected index names declared in the code.
+/// </summary>
+internal sealed class SearchIndexDeleter
+{
+    private readonly IMongoDatabase _database;
+    private readonly ILogger _logger;
+    private readonly Dictionary<string, IList<string>> _expectedSearchIndexNames;
+    private readonly CancellationToken _cancellationToken;
+
+    private SearchIndexDeleter(IMongoDatabase database, Dictionary<string, IList<string>> expectedSearchIndexNames, ILogger<SearchIndexDeleter> logger, CancellationToken cancellationToken)
+    {
+        this._database = database;
+        this._logger = logger;
+        this._cancellationToken = cancellationToken;
+        this._expectedSearchIndexNames = expectedSearchIndexNames;
+    }
+
+    public static Task ProcessAsync(IMongoDatabase database, Dictionary<string, IList<string>> expectedSearchIndexNames, ILoggerFactory loggerFactory, CancellationToken cancellationToken)
+    {
+        return new SearchIndexDeleter(database, expectedSearchIndexNames, loggerFactory.CreateLogger<SearchIndexDeleter>(), cancellationToken).ProcessAsync();
+    }
+
+    private async Task ProcessAsync()
+    {
+        foreach (var (collectionName, expectedNames) in this._expectedSearchIndexNames)
+        {
+            this._cancellationToken.ThrowIfCancellationRequested();
+
+            List<string> existingNames;
+            try
+            {
+                existingNames = await this.GetExistingSearchIndexNamesAsync(collectionName).ConfigureAwait(false);
+            }
+            catch (MongoCommandException ex) when (IsSearchNotSupportedException(ex))
+            {
+                this._logger.AtlasSearchNotAvailable(ex, this._database.DatabaseNamespace.DatabaseName);
+                return;
+            }
+
+            this._cancellationToken.ThrowIfCancellationRequested();
+
+            var expectedNameSet = new HashSet<string>(expectedNames, StringComparer.Ordinal);
+            var collection = this._database.GetCollection<BsonDocument>(collectionName);
+
+            foreach (var existingName in existingNames)
+            {
+                if (!expectedNameSet.Contains(existingName))
+                {
+                    try
+                    {
+                        this._logger.DroppingOrphanedSearchIndex(existingName, collectionName, this._database.DatabaseNamespace.DatabaseName);
+                        await collection.SearchIndexes.DropOneAsync(existingName, this._cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (MongoCommandException ex) when (IsSearchNotSupportedException(ex))
+                    {
+                        this._logger.AtlasSearchNotAvailable(ex, this._database.DatabaseNamespace.DatabaseName);
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+    private async Task<List<string>> GetExistingSearchIndexNamesAsync(string collectionName)
+    {
+        var names = new List<string>();
+        var collection = this._database.GetCollection<BsonDocument>(collectionName);
+
+        using var cursor = await collection.SearchIndexes.ListAsync(null, null, this._cancellationToken).ConfigureAwait(false);
+        var indexes = await cursor.ToListAsync(this._cancellationToken).ConfigureAwait(false);
+
+        foreach (var index in indexes)
+        {
+            names.Add(index["name"].AsString);
+        }
+
+        return names;
+    }
+
+    private static bool IsSearchNotSupportedException(MongoCommandException ex)
+    {
+        // Error code 31082 is returned by non-Atlas clusters that do not have the mongot process running.
+        // https://www.mongodb.com/docs/atlas/atlas-search/atlas-search-overview/
+        return ex.Code == 31082;
+    }
+}

--- a/src/Workleap.Extensions.Mongo/LoggingExtensions.cs
+++ b/src/Workleap.Extensions.Mongo/LoggingExtensions.cs
@@ -51,4 +51,20 @@ internal static partial class LoggingExtensions
     // CommandPerformanceAnalyzer
     [LoggerMessage(14, LogLevel.Warning, "Collection scan detected on command {MongoRequestId}")]
     public static partial void CollectionScanDetected(this ILogger logger, int mongoRequestId);
+
+    // SearchIndexCreator / SearchIndexDeleter
+    [LoggerMessage(15, LogLevel.Information, "Skipping {DocumentType} search index {IndexName} as it is already up-to-date on the database {DatabaseName}")]
+    public static partial void SkippingUpToDateSearchIndex(this ILogger logger, string documentType, string indexName, string databaseName);
+
+    [LoggerMessage(16, LogLevel.Information, "Creating {DocumentType} search index {IndexName} for the first time on the database {DatabaseName}")]
+    public static partial void CreatingNewSearchIndex(this ILogger logger, string documentType, string indexName, string databaseName);
+
+    [LoggerMessage(17, LogLevel.Information, "Updating {DocumentType} search index {IndexName} as its definition has changed on the database {DatabaseName}")]
+    public static partial void UpdatingSearchIndex(this ILogger logger, string documentType, string indexName, string databaseName);
+
+    [LoggerMessage(18, LogLevel.Information, "Dropping orphaned search index {IndexName} on collection {CollectionName} on the database {DatabaseName}")]
+    public static partial void DroppingOrphanedSearchIndex(this ILogger logger, string indexName, string collectionName, string databaseName);
+
+    [LoggerMessage(19, LogLevel.Warning, "Atlas Search is not available on the database {DatabaseName}. Skipping search index management.")]
+    public static partial void AtlasSearchNotAvailable(this ILogger logger, Exception exception, string databaseName);
 }


### PR DESCRIPTION
Jira issue link: [EP-5668](https://workleap.atlassian.net/browse/EP-5668)

## Description of changes
We are using Atlas Search more nowadays (at least the WLP and OV) and the library does not support managed indexing. This PR is a proposal to support it through the existing MongoIndexer/MongoIndexProvider apis. The main difference is that the driver does not use the same definition class (CreateIndexModel vs CreateSearchIndexModel). Another key implementation detail is that we cannot/should not use hashing in the index name. For regular indexes this is useful because the regular api does not support updating the index so we need to first delete then recreate the index with the new definition. Search supports updates, so we don't need to persist the hash. Moreover, The standard way to use the index is to reference its name, ie.:

```
        var result = await this.FeedbackCollection
            .Aggregate()
            .Search(searchDefinition, new SearchOptions<SurveyConversationDocument>
            {
                IndexName = isAdvancedReportingEnabled
                            ? SurveyConversationAdvancedReportingAtlasSearchIndex.IndexName
                            : SurveyConversationDefaultAtlasSearchIndex.IndexName
            })
            .Facet(facetBuckets.Values.ToArray<AggregateFacet<SurveyConversationDocument>>())
            .SingleOrDefaultAsync(cancellationToken);
```

We need to keep the name static to avoid breaking the code whenever the definition changes.

## Breaking changes
No expected breaking changes, this is a new method.

## Additional checks
Most docker local environments don't spin a mongot process, the lib will silently fail atlas search index creations.

OV tried to create a homebrew solution to this problem in the past prior to the migration to this lib using a [job](https://github.com/workleap/ov-monorepo/blob/master/feedback/src/Officevibe.Feedback.Domain/Feedbacks/Summaries/AtlasSearch/CreateAtlasSearchIndexJob.cs) and a [string based bson definition](https://github.com/workleap/ov-monorepo/blob/master/feedback/src/Officevibe.Feedback.Domain/Feedbacks/Summaries/AtlasSearch/SurveyConversationAdvancedReportingAtlasSearchIndex.cs).

- [x] Updated the documentation of the project to reflect the changes
- [x] Added new tests that cover the code changes


[EP-5668]: https://workleap.atlassian.net/browse/EP-5668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ